### PR TITLE
Fix input and return type in fib.ts

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n:number) {
   if (n < 0) {
     return -1;
   } else if (n == 0) {

--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n:number) {
+export default function fibonacci(n:number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
Specified the parameter of fibonacci(n) to be number. Also specified the return value of the function to be number.
Fixes issue #1 